### PR TITLE
Blood: Add User Map menu to episode select, fixes #202

### DIFF
--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -585,7 +585,7 @@ void StartLevel(GAMEOPTIONS *gameOptions)
         if (gEpisodeInfo[gGameOptions.nEpisode].cutALevel == gGameOptions.nLevel
             && gEpisodeInfo[gGameOptions.nEpisode].at8f08)
             gGameOptions.uGameFlags |= 4;
-        if ((gGameOptions.uGameFlags&4) && gDemo.at1 == 0)
+        if ((gGameOptions.uGameFlags&4) && gDemo.at1 == 0 && !Bstrlen(gGameOptions.szUserMap))
             levelPlayIntroScene(gGameOptions.nEpisode);
 
         ///////

--- a/source/blood/src/gamemenu.cpp
+++ b/source/blood/src/gamemenu.cpp
@@ -366,10 +366,6 @@ bool CGameMenu::Event(CGameMenuEvent &event)
 void CGameMenu::Add(CGameMenuItem *pItem, bool active)
 {
     dassert(pItem != NULL);
-    if (!(m_nItems < kMaxGameMenuItems))
-    {
-        int a = 0;
-    }
     dassert(m_nItems < kMaxGameMenuItems);
     pItemList[m_nItems] = pItem;
     pItem->pMenu = this;
@@ -380,10 +376,6 @@ void CGameMenu::Add(CGameMenuItem *pItem, bool active)
 
 void CGameMenu::SetFocusItem(int nItem)
 {
-    if (!(nItem >= 0 && nItem < m_nItems && nItem < kMaxGameMenuItems))
-    {
-        int a = 0;
-    }
     dassert(nItem >= 0 && nItem < m_nItems && nItem < kMaxGameMenuItems);
     if (CanSelectItem(nItem))
         m_nFocus = at8 = nItem;
@@ -670,7 +662,6 @@ CGameMenuItemChain::CGameMenuItemChain()
     at28 = -1;
     at2c = NULL;
     at30 = 0;
-    isUserMap = false;
 }
 
 CGameMenuItemChain::CGameMenuItemChain(const char *a1, int a2, int a3, int a4, int a5, int a6, CGameMenu *a7, int a8, void(*a9)(CGameMenuItemChain *), int a10)
@@ -740,10 +731,7 @@ bool CGameMenuItemChain::Event(CGameMenuEvent &event)
         if (at2c)
             at2c(this);
         if (at24)
-        {
-            Bstrcpy(gGameOptions.szUserMap, isUserMap ? m_pzText : "\0");
             gGameMenuMgr.Push(at24, at28);
-        }
         return false;
     }
     return CGameMenuItem::Event(event);
@@ -996,7 +984,10 @@ bool CGameMenuItemChain7F2F0::Event(CGameMenuEvent &event)
     {
     case kMenuEventEnter:
         if (at34 > -1)
+        {
             gGameOptions.nEpisode = at34;
+            Bstrcpy(gGameOptions.szUserMap, "\0");
+        }
         return CGameMenuItemChain::Event(event);
     }
     return CGameMenuItem::Event(event);
@@ -2482,12 +2473,16 @@ void CGameMenuItemZCycle::Draw(void)
     int x = m_nX;
     int y = m_nY;
 
+    bool isUserMapMenuItem = !Bstrcmp("USER MAP", m_pzText) && m_nWidth == 321 && m_pCallback; // shameful hax
+
     if (m_nMenuSelectReturn != -1)
     {
         m_nFocus = m_nMenuSelectReturn;
         if (m_pCallback)
             m_pCallback(this);
         m_nMenuSelectReturn = -1;
+        if (isUserMapMenuItem)
+            gGameMenuMgr.Push(&menuDifficulty, 3);
     }
 
     if (m_pzText)
@@ -2505,7 +2500,7 @@ void CGameMenuItemZCycle::Draw(void)
         default:
             break;
         }
-        gMenuTextMgr.DrawText(m_pzText, m_nFont, x, y, shade, pal, false);
+        gMenuTextMgr.DrawText(m_pzText, m_nFont, x, y, shade, pal, isUserMapMenuItem);
     }
     const char *pzText;
     if (!m_nItems)
@@ -2514,7 +2509,8 @@ void CGameMenuItemZCycle::Draw(void)
         pzText = m_pzStrings[m_nFocus];
     dassert(pzText != NULL);
     gMenuTextMgr.GetFontInfo(m_nFont, pzText, &width, NULL);
-    gMenuTextMgr.DrawText(pzText, m_nFont, m_nX + m_nWidth - 1 - width, y, shade, pal, false);
+    if (!isUserMapMenuItem)
+        gMenuTextMgr.DrawText(pzText, m_nFont, m_nX + m_nWidth - 1 - width, y, shade, pal, false);
     if (bEnable && MOUSEACTIVECONDITIONAL(!gGameMenuMgr.MouseOutsideBounds(&gGameMenuMgr.m_mousepos, x<<16, y<<16, m_nWidth<<16, height<<16)))
     {
         if (MOUSEWATCHPOINTCONDITIONAL(!gGameMenuMgr.MouseOutsideBounds(&gGameMenuMgr.m_prevmousepos, x<<16, y<<16, m_nWidth<<16, height<<16)))

--- a/source/blood/src/gamemenu.cpp
+++ b/source/blood/src/gamemenu.cpp
@@ -366,6 +366,10 @@ bool CGameMenu::Event(CGameMenuEvent &event)
 void CGameMenu::Add(CGameMenuItem *pItem, bool active)
 {
     dassert(pItem != NULL);
+    if (!(m_nItems < kMaxGameMenuItems))
+    {
+        int a = 0;
+    }
     dassert(m_nItems < kMaxGameMenuItems);
     pItemList[m_nItems] = pItem;
     pItem->pMenu = this;
@@ -376,6 +380,10 @@ void CGameMenu::Add(CGameMenuItem *pItem, bool active)
 
 void CGameMenu::SetFocusItem(int nItem)
 {
+    if (!(nItem >= 0 && nItem < m_nItems && nItem < kMaxGameMenuItems))
+    {
+        int a = 0;
+    }
     dassert(nItem >= 0 && nItem < m_nItems && nItem < kMaxGameMenuItems);
     if (CanSelectItem(nItem))
         m_nFocus = at8 = nItem;
@@ -662,6 +670,7 @@ CGameMenuItemChain::CGameMenuItemChain()
     at28 = -1;
     at2c = NULL;
     at30 = 0;
+    isUserMap = false;
 }
 
 CGameMenuItemChain::CGameMenuItemChain(const char *a1, int a2, int a3, int a4, int a5, int a6, CGameMenu *a7, int a8, void(*a9)(CGameMenuItemChain *), int a10)
@@ -731,7 +740,10 @@ bool CGameMenuItemChain::Event(CGameMenuEvent &event)
         if (at2c)
             at2c(this);
         if (at24)
+        {
+            Bstrcpy(gGameOptions.szUserMap, isUserMap ? m_pzText : "\0");
             gGameMenuMgr.Push(at24, at28);
+        }
         return false;
     }
     return CGameMenuItem::Event(event);

--- a/source/blood/src/gamemenu.h
+++ b/source/blood/src/gamemenu.h
@@ -31,8 +31,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #define M_MOUSETIMEOUT 210
 
-#define kMaxGameMenuItems 1280
-#define kMaxGameCycleItems 128
+#define kMaxGameMenuItems 128
+#define kMaxGameCycleItems 1280
 #define kMaxPicCycleItems 128
 #define kMaxTitleLength 32
 
@@ -155,7 +155,6 @@ public:
     int at28;
     void(*at2c)(CGameMenuItemChain *);
     int at30;
-    bool isUserMap;
     CGameMenuItemChain();
     CGameMenuItemChain(const char *, int, int, int, int, int, CGameMenu *, int, void(*)(CGameMenuItemChain *), int);
     virtual void Draw(void);

--- a/source/blood/src/gamemenu.h
+++ b/source/blood/src/gamemenu.h
@@ -31,7 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #define M_MOUSETIMEOUT 210
 
-#define kMaxGameMenuItems 128
+#define kMaxGameMenuItems 1280
 #define kMaxGameCycleItems 128
 #define kMaxPicCycleItems 128
 #define kMaxTitleLength 32
@@ -155,6 +155,7 @@ public:
     int at28;
     void(*at2c)(CGameMenuItemChain *);
     int at30;
+    bool isUserMap;
     CGameMenuItemChain();
     CGameMenuItemChain(const char *, int, int, int, int, int, CGameMenu *, int, void(*)(CGameMenuItemChain *), int);
     virtual void Draw(void);

--- a/source/blood/src/levels.h
+++ b/source/blood/src/levels.h
@@ -57,6 +57,7 @@ struct GAMEOPTIONS {
     int weaponsV10x;
     bool bFriendlyFire;
     bool bKeepKeysOnRespawn;
+    char szUserMap[BMAX_PATH];
 };
 
 #pragma pack(pop)

--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -43,6 +43,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 void SaveGame(CGameMenuItemZEditBitmap *, CGameMenuEvent *);
 
 void SaveGameProcess(CGameMenuItemChain *);
+void SetCustomMap(CGameMenuItemZCycle *pItem);
 void SetDifficultyAndStart(CGameMenuItemChain *);
 void SetDetail(CGameMenuItemSlider *);
 void SetGamma(CGameMenuItemSlider *);
@@ -179,7 +180,6 @@ CGameMenu menuNetMain;
 CGameMenu menuNetStart;
 CGameMenu menuEpisode;
 CGameMenu menuDifficulty;
-CGameMenu menuUserMaps;
 CGameMenu menuOptionsOld;
 CGameMenu menuControls;
 CGameMenu menuMessages;
@@ -229,10 +229,9 @@ CGameMenuItemChain itemMainSave7("END GAME", 1, 0, 135, 320, 1, &menuRestart, -1
 CGameMenuItemChain itemMainSave8("QUIT", 1, 0, 150, 320, 1, &menuQuit, -1, NULL, 0);
 
 CGameMenuItemTitle itemEpisodesTitle("EPISODES", 1, 160, 20, 2038);
-CGameMenuItemChain7F2F0 itemEpisodes[kMaxEpisodes]; // plus 1 for User Map
+CGameMenuItemChain7F2F0 itemEpisodes[kMaxEpisodes-1];
 
-CGameMenuItemTitle itemUserMapTitle("USER MAP", 1, 160, 20, 2038);
-CGameMenuItemChain itemUserMaps[kMaxGameMenuItems];
+CGameMenuItemZCycle itemUserMapCycle("USER MAP", 1, 160, 60, 320, 0, SetCustomMap, NULL, 0, 0, true);
 
 CGameMenuItemTitle itemDifficultyTitle("DIFFICULTY", 1, 160, 20, 2038);
 CGameMenuItemChain itemDifficulty1("STILL KICKING", 1, 0, 60, 320, 1, NULL, -1, SetDifficultyAndStart, 0);
@@ -378,6 +377,8 @@ struct resolution_t {
 resolution_t gResolution[MAXVALIDMODES];
 int gResolutionNum;
 const char *gResolutionName[MAXVALIDMODES];
+
+const char *customMaps[kMaxGameCycleItems-1];
 
 CGameMenu menuOptions;
 CGameMenu menuOptionsGame;
@@ -823,33 +824,6 @@ void SetupDifficultyMenu(void)
     menuDifficulty.Add(&itemBloodQAV, false);
 }
 
-void SetupUserMapsMenu(void)
-{
-    menuUserMaps.Add(&itemUserMapTitle, false);
-
-    BUILDVFS_FIND_REC *r;
-    fnlist_t fnlist = FNLIST_INITIALIZER;
-
-    char filename[BMAX_PATH];
-    Bstrcpy(filename, "*.MAP");
-
-    fnlist_getnames(&fnlist, "/", filename, -1, 0);
-    gSysRes.FNAddFiles(&fnlist, filename);
-
-    int i = 0;
-    int x = 30;
-    for (r=fnlist.findfiles; r; r=r->next)
-    {
-        itemUserMaps[i] = CGameMenuItemChain(r->name, 3, 0, x, 320, 1, &menuDifficulty, -1, NULL, i);
-        itemUserMaps[i].isUserMap = true;
-        menuUserMaps.Add(&itemUserMaps[i], false);
-        i++;
-        x+=10;
-    }
-
-    menuUserMaps.Add(&itemBloodQAV, false);
-}
-
 void SetupEpisodeMenu(void)
 {
     menuEpisode.Add(&itemEpisodesTitle, false);
@@ -896,20 +870,33 @@ void SetupEpisodeMenu(void)
     }
 
     // User Map
-    CGameMenuItemChain7F2F0 *pEpisodeItem = &itemEpisodes[kMaxEpisodes-1]; // the last is reserved for User Map
-    pEpisodeItem->m_nFont = 1;
-    pEpisodeItem->m_nX = 0;
-    pEpisodeItem->m_nWidth = 320;
-    pEpisodeItem->at20 = 1;
-    pEpisodeItem->m_pzText = "User Map";
-    pEpisodeItem->m_nY = 55+(height+8)*j;
-    pEpisodeItem->at24 = &menuUserMaps;
-    pEpisodeItem->at28 = 1;
-    pEpisodeItem->bCanSelect = 1;
-    pEpisodeItem->bEnable = 1;
-    SetupUserMapsMenu();
-    menuEpisode.Add(&itemEpisodes[kMaxEpisodes-1], false);
+    BUILDVFS_FIND_REC *r;
+    fnlist_t fnlist = FNLIST_INITIALIZER;
 
+    char filename[BMAX_PATH];
+    Bstrcpy(filename, "*.MAP");
+
+    fnlist_getnames(&fnlist, "/", filename, -1, 0);
+    gSysRes.FNAddFiles(&fnlist, filename);
+
+    int i = 0;
+    for (r=fnlist.findfiles; r; r=r->next)
+    {
+        if (i >= kMaxGameCycleItems)
+            break;
+
+        customMaps[i] = r->name;
+        i++;
+    }
+
+    itemUserMapCycle.SetTextArray(customMaps, i, 0);
+    itemUserMapCycle.m_nX = 125;
+    itemUserMapCycle.m_nWidth = 321;
+    itemUserMapCycle.m_nY = 55+(height+8)*(gEpisodeCount-1);
+    itemUserMapCycle.bCanSelect = 1;
+    itemUserMapCycle.bEnable = 1;
+
+    menuEpisode.Add(&itemUserMapCycle, false);
     menuEpisode.Add(&itemBloodQAV, false);
 }
 
@@ -1605,6 +1592,11 @@ void SetWeaponSwitch(CGameMenuItemZCycle *pItem)
 }
 
 extern bool gStartNewGame;
+
+void SetCustomMap(CGameMenuItemZCycle *pItem)
+{
+    Bstrcpy(gGameOptions.szUserMap, customMaps[pItem->m_nFocus]);
+}
 
 void SetDifficultyAndStart(CGameMenuItemChain *pItem)
 {


### PR DESCRIPTION
Currently the users are only able to play custom maps (if they don't have an .ini file) by entering commands into the console. Selecting the difficulty is not possible this way, the previously used difficulty will be used (by default Lightly Broiled). This is not really intuitive for users.